### PR TITLE
Add task id and title in several places and color enhancements

### DIFF
--- a/Assets/chart.js
+++ b/Assets/chart.js
@@ -68,6 +68,7 @@ Gantt.prototype.renderVerticalHeader = function() {
             .append("&nbsp;");
 
         if (this.data[i].type == "task") {
+            content.append(jQuery('<strong>').text('#'+this.data[i].id+' '));
             content.append(jQuery("<a>", {"href": this.data[i].link, "title": this.data[i].title}).text(this.data[i].title));
         }
         else {
@@ -181,7 +182,12 @@ Gantt.prototype.addBlocks = function(slider, start) {
         var series = this.data[i];
         var size = this.daysBetween(series.start, series.end) + 1;
         var offset = this.daysBetween(start, series.start);
-        var text = jQuery("<div>", {"class": "ganttview-block-text"});
+        var text = jQuery("<div>", {
+          "class": "ganttview-block-text",
+          "css": {
+              "width": ((size * this.options.cellWidth) - 19) + "px"
+          }
+        });
 
         var block = jQuery("<div>", {
             "class": "ganttview-block tooltip" + (this.options.allowMoves ? " ganttview-block-movable" : ""),
@@ -194,6 +200,9 @@ Gantt.prototype.addBlocks = function(slider, start) {
 
         if (size >= 2) {
             text.append(series.progress);
+        }
+        if (size >= 4) {
+          text.append(' - #'+series.id+' '+series.title);
         }
 
         block.data("record", series);
@@ -213,7 +222,7 @@ Gantt.prototype.getVerticalHeaderTooltip = function(record) {
                 .append(jQuery("<strong>").text(record.column_title))
                 .append(document.createTextNode(' (' + record.progress + ')'))
                 .append(jQuery("<br>"))
-                .append(document.createTextNode(record.title)).prop('outerHTML');
+                .append(document.createTextNode('#'+record.id+' '+record.title)).prop('outerHTML');
     }
     else {
         var types = ["project-manager", "project-member"];
@@ -247,7 +256,7 @@ Gantt.prototype.getBarTooltip = function(record) {
     else {
         if (record.type == "task") {
             var assigneeLabel = $(this.options.container).data("label-assignee");
-            tooltip += jQuery("<strong>").text(record.progress).prop('outerHTML');
+            tooltip += jQuery("<strong>").text('#'+record.id+' '+record.title+' ('+record.progress+')').prop('outerHTML');
             tooltip += "<br>";
             tooltip += jQuery('<span>').append(document.createTextNode(assigneeLabel + " " + (record.assignee ? record.assignee : ''))).prop('outerHTML');
             tooltip += "<br>";

--- a/Assets/chart.js
+++ b/Assets/chart.js
@@ -250,10 +250,6 @@ Gantt.prototype.getVerticalHeaderTooltip = function(record) {
 Gantt.prototype.getBarTooltip = function(record) {
     var tooltip = "";
 
-    if (record.not_defined) {
-        tooltip = $(this.options.container).data("label-not-defined");
-    }
-    else {
         if (record.type == "task") {
             var assigneeLabel = $(this.options.container).data("label-assignee");
             tooltip += jQuery("<strong>").text('#'+record.id+' '+record.title+' ('+record.progress+')').prop('outerHTML');
@@ -262,35 +258,42 @@ Gantt.prototype.getBarTooltip = function(record) {
             tooltip += "<br>";
         }
 
+        if (record.not_defined) {
+          tooltip += jQuery("<i>").text($(this.options.container).data("label-not-defined")).prop('outerHTML');
+          tooltip += "<br>";
+        }
         tooltip += $(this.options.container).data("label-start-date") + " " + $.datepicker.formatDate('yy-mm-dd', record.start) + "<br/>";
         tooltip += $(this.options.container).data("label-end-date") + " " + $.datepicker.formatDate('yy-mm-dd', record.end);
-    }
 
     return tooltip;
 };
 
 // Set bar color
 Gantt.prototype.setBarColor = function(block, record) {
+    block.css("background-color", record.color.background);
+    block.css("border-color", record.color.border);
     if (record.not_defined) {
         block.addClass("ganttview-block-not-defined");
-    }
-    else {
-        block.css("background-color", record.color.background);
-        block.css("border-color", record.color.border);
-
-        if (record.progress != "0%") {
-            block.append(jQuery("<div>", {
-                "css": {
-                    "z-index": 0,
-                    "position": "absolute",
-                    "top": 0,
-                    "bottom": 0,
-                    "background-color": record.color.border,
-                    "width": record.progress,
-                    "opacity": 0.4
-                }
-            }));
+        if (record.date_started_not_defined) {
+            block.css("border-left", "2px solid gray");
         }
+        if (record.date_due_not_defined) {
+          block.css("border-right", "2px solid gray");
+        }
+    }
+
+    if (record.progress != "0%") {
+        block.append(jQuery("<div>", {
+            "css": {
+                "z-index": 0,
+                "position": "absolute",
+                "top": 0,
+                "bottom": 0,
+                "background-color": record.color.border,
+                "width": record.progress,
+                "opacity": 0.4
+            }
+        }));
     }
 };
 

--- a/Assets/chart.js
+++ b/Assets/chart.js
@@ -343,12 +343,23 @@ Gantt.prototype.updateDataAndPosition = function(block, startDate) {
     // Set new start date
     var daysFromStart = Math.round(offset / this.options.cellWidth);
     var newStart = this.addDays(this.cloneDate(startDate), daysFromStart);
-    record.start = newStart;
+    if (!record.date_started_not_defined || this.compareDate(newStart, record.start)) {
+        record.start = this.addDays(this.cloneDate(startDate), daysFromStart+1);
+    }
+    else if (record.date_started_not_defined) {
+        delete record.start;
+    }
 
     // Set new end date
     var width = block.outerWidth();
     var numberOfDays = Math.round(width / this.options.cellWidth) - 1;
-    record.end = this.addDays(this.cloneDate(newStart), numberOfDays);
+    var newEnd = this.addDays(this.cloneDate(newStart), numberOfDays);
+    if (!record.date_due_not_defined || this.compareDate(newEnd, record.end)) {
+        record.end = newEnd;
+    }
+    else if (record.date_due_not_defined) {
+        delete record.end;
+    }
 
     if (record.type === "task" && numberOfDays > 0) {
         jQuery("div.ganttview-block-text", block).text(record.progress);

--- a/Assets/gantt.css
+++ b/Assets/gantt.css
@@ -112,11 +112,6 @@ div.ganttview-block {
     cursor: move;
 }
 
-div.ganttview-block-not-defined {
-    border-color: #000;
-    background-color: #000;
-}
-
 div.ganttview-block-text {
     position: absolute;
     height: 12px;

--- a/Assets/gantt.css
+++ b/Assets/gantt.css
@@ -123,6 +123,9 @@ div.ganttview-block-text {
     font-size: 0.7em;
     color: #999;
     padding: 2px 3px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 div.ganttview-block div.ui-resizable-handle.ui-resizable-s {

--- a/Formatter/TaskGanttFormatter.php
+++ b/Formatter/TaskGanttFormatter.php
@@ -20,7 +20,7 @@ class TaskGanttFormatter extends BaseFormatter implements FormatterInterface
      * @var array
      */
     private $columns = array();
-    
+
     /**
      * Apply formatter
      *
@@ -74,6 +74,8 @@ class TaskGanttFormatter extends BaseFormatter implements FormatterInterface
             'link' => $this->helper->url->href('TaskViewController', 'show', array('project_id' => $task['project_id'], 'task_id' => $task['id'])),
             'color' => $this->colorModel->getColorProperties($task['color_id']),
             'not_defined' => empty($task['date_due']) || empty($task['date_started']),
+            'date_started_not_defined' => empty($task['date_started']),
+            'date_due_not_defined' => empty($task['date_due']),
         );
     }
 }


### PR DESCRIPTION
I have few updates on the Gantt plugin to facilitate reading:

* Add task id and title in several places and prevent "text out of box" issue
* Use new date_due_not_defined and date_started_not_defined to show "gray" border instead of a completely black element
* Only update start / due date if it has changed (this avoid to hide inheritance from milestone or blocking task if plugin "Milestone" is used)

Linked with the Milestone plugin, it allows to display stuff like this (I only sets dates to 3 tasks in this diagram):

![screenshot_20170711_154905](https://user-images.githubusercontent.com/953989/28071551-8865d6d2-6650-11e7-80b0-158ea155a472.png)

Could you please consider adding it to the plugin?

