### PR TITLE
print styling support

### DIFF
--- a/Assets/gantt.css
+++ b/Assets/gantt.css
@@ -134,3 +134,139 @@ div.ganttview-progress-bar {
     bottom: 0;
     opacity: 0.4;
 }
+
+/* print styling */
+@media print {
+ .ganttview-hzheader-months {
+ max-width: 100%;
+}
+ div.ganttview-hzheader-month, div.ganttview-hzheader-day, div.ganttview-vtheader, div.ganttview-vtheader-item-name, div.ganttview-vtheader-series, div.ganttview-grid, div.ganttview-grid-row-cell {
+    float: left;
+}
+
+div.ganttview-hzheader-month, div.ganttview-hzheader-day {
+    text-align: center;
+}
+
+div.ganttview-grid-row-cell.last, div.ganttview-hzheader-day.last, div.ganttview-hzheader-month.last {
+    border-right: none;
+}
+
+div.ganttview {
+    border: 1px solid #999;
+}
+
+div.ganttview-hzheader-month {
+    width: 60px;
+    height: 20px;
+    border-right: 1px solid #d0d0d0;
+    line-height: 20px;
+    overflow: hidden;
+}
+
+div.ganttview-hzheader-day {
+    width: 20px;
+    height: 20px;
+    border-right: 1px solid #f0f0f0;
+    border-top: 1px solid #d0d0d0;
+    line-height: 20px;
+    color: #555;
+}
+
+div.ganttview-vtheader {
+    margin-top: 41px;
+    width: 400px;
+    overflow: hidden;
+    background-color: #fff;
+}
+
+div.ganttview-vtheader-item {
+    color: #555;
+}
+
+div.ganttview-vtheader-series-name {
+    width: 400px;
+    height: 31px;
+    line-height: 31px;
+    padding-left: 3px;
+    border-top: 1px solid #d0d0d0;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+}
+
+div.ganttview-vtheader-series-name a {
+    color: #555;
+    text-decoration: none;
+}
+
+div.ganttview-vtheader-series-name a:hover {
+    color: #333;
+    text-decoration: underline;
+}
+
+div.ganttview-vtheader-series-name a i {
+    color: #000;
+}
+
+div.ganttview-vtheader-series-name a:hover i {
+    color: #555;
+}
+
+div.ganttview-slide-container {
+    overflow: auto;
+    border-left: 1px solid #999;
+}
+
+div.ganttview-grid-row-cell {
+    width: 20px;
+    height: 31px;
+    border-right: 1px solid #f0f0f0;
+    border-top: 1px solid #f0f0f0;
+}
+
+div.ganttview-grid-row-cell.ganttview-weekend {
+    background-color: #fafafa;
+}
+
+div.ganttview-grid-row-cell.ganttview-today {
+    background-color: #fcf8e3;
+}
+
+div.ganttview-blocks {
+    margin-top: 40px;
+}
+
+div.ganttview-block-container {
+    height: 28px;
+    padding-top: 4px;
+}
+
+div.ganttview-block {
+    position: relative;
+    height: 25px;
+    background-color: #E5ECF9;
+    border: 1px solid #c0c0c0;
+    border-radius: 3px;
+}
+
+.ganttview-block-movable {
+    cursor: move;
+}
+
+div.ganttview-block-text {
+    position: absolute;
+    height: 12px;
+    font-size: 0.7em;
+    color: #999;
+    padding: 2px 3px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+div.ganttview-block div.ui-resizable-handle.ui-resizable-s {
+    bottom: 0;
+}
+    
+} /* end print styling */

--- a/Plugin.php
+++ b/Plugin.php
@@ -55,7 +55,7 @@ class Plugin extends Base
 
     public function getPluginVersion()
     {
-        return '1.0.4';
+        return '1.0.5';
     }
 
     public function getPluginHomepage()


### PR DESCRIPTION
added the styling to the media print css tag.
The width on the month board header is a little off but will attempt to print what is visible. People are welcome to adjust this as they so desire.

Also adding this to a kanboard custom css will remove things like the menu & alert at the bottom
```css
@media print {
@page {
        orientation:landscape;
        -webkit-transform: rotate(-90deg); 
        -moz-transform:rotate(-90deg);
        filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
    }
    #board-container { overflow-x: initial !important; }
    .board-task-list { min-height: 0 !important; }
    .task-board      { page-break-inside: avoid; }
   
   /*Hide menu */
  .menu-inline, .project-header, .menus-container, .alert, .alert-info { display: none; }
}
```

This fixes:
#14 
[#1329](https://github.com/kanboard/kanboard/issues/1329)

And is related to:
[#3188](https://github.com/kanboard/kanboard/issues/3188)