### PR TITLE
Fix tasks not aligned on grid

### DIFF
--- a/Assets/gantt.css
+++ b/Assets/gantt.css
@@ -96,7 +96,7 @@ div.ganttview-blocks {
 }
 
 div.ganttview-block-container {
-    height: 28px;
+    height: 31px;
     padding-top: 4px;
 }
 


### PR DESCRIPTION
On plugin v1.0.6 (current version) on Firefox 80.0.1 and kanboard 1.2.15, tasks and the grid are misaligned. Correcting ganttview-block-container to 31px (size of the grid) fix the issue.